### PR TITLE
About link changed to redirect to labexp

### DIFF
--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-	<string name="about_link"><a href="https://github.com/nguillaumin/osmtracker-android">https://github.com/nguillaumin/osmtracker-android</a></string>
+	<string name="about_link"><a href="https://github.com/labexp/osmtracker-android">https://github.com/labexp/osmtracker-android</a></string>
     <string name="about_translate_link">https://www.transifex.com/projects/p/osmtracker-android/</string>
     
 </resources>


### PR DESCRIPTION
The link has been changed from 
`https://github.com/nguillaumin/osmtracker-android`
to
`https://github.com/labexp/osmtracker-android`